### PR TITLE
simplify model deployment

### DIFF
--- a/examples/Create_Models_existing_OpenAI_Service/common.auto.tfvars
+++ b/examples/Create_Models_existing_OpenAI_Service/common.auto.tfvars
@@ -27,18 +27,14 @@ openai_resource_group_name = "Terraform-Exisiting-Cognitive-Services-rg"
 create_model_deployment = true
 model_deployment = [
   {
-    deployment_no = 1
-    deployment_id = "pwd1003-gpt-35-turbo-16k"
-    api_type      = "azure"
+    deployment_id = "gpt35turbo16k"
     model         = "gpt-35-turbo-16k"
     model_format  = "OpenAI"
     model_version = "0613"
     scale_type    = "Standard"
   },
   {
-    deployment_no = 2
-    deployment_id = "pwd1003-gpt-35-turbo"
-    api_type      = "azure"
+    deployment_id = "gpt35turbo"
     model         = "gpt-35-turbo"
     model_format  = "OpenAI"
     model_version = "0613"

--- a/examples/Create_Models_existing_OpenAI_Service/variables.tf
+++ b/examples/Create_Models_existing_OpenAI_Service/variables.tf
@@ -84,10 +84,8 @@ variable "create_model_deployment" {
 
 variable "model_deployment" {
   type = list(object({
-    deployment_no   = number
     deployment_id   = string
-    api_type        = string
-    model           = string
+    model_name      = string
     model_format    = string
     model_version   = string
     scale_type      = string
@@ -100,12 +98,10 @@ variable "model_deployment" {
   default     = []
   description = <<-DESCRIPTION
       type = list(object({
-        deployment_no   = (Required) The unique number of each model deployment (Numbered when saved in Azure Key Vault).
         deployment_id   = (Required) The name of the Cognitive Services Account `Model Deployment`. Changing this forces a new resource to be created.
-        api_type        = (Required) The type of the Cognitive Services Account `Model Deployment`. Possible values are `azure`.
-        model = {
+        model_name = {
           model_format  = (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is OpenAI.
-          model         = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
+          model_name    = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
           model_version = (Required) The version of Cognitive Services Account Deployment model.
         }
         scale = {

--- a/examples/Create_OpenAI_Service_and_Models/common.auto.tfvars
+++ b/examples/Create_OpenAI_Service_and_Models/common.auto.tfvars
@@ -34,18 +34,14 @@ openai_identity = {
 create_model_deployment = true
 model_deployment = [
   {
-    deployment_no = 1
-    deployment_id = "pwd1001-gpt-35-turbo-16k"
-    api_type      = "azure"
+    deployment_id = "gpt35turbo16k"
     model         = "gpt-35-turbo-16k"
     model_format  = "OpenAI"
     model_version = "0613"
     scale_type    = "Standard"
   },
   {
-    deployment_no = 2
-    deployment_id = "pwd1001-gpt-35-turbo"
-    api_type      = "azure"
+    deployment_id = "gpt35turbo"
     model         = "gpt-35-turbo"
     model_format  = "OpenAI"
     model_version = "0613"

--- a/examples/Create_OpenAI_Service_and_Models/variables.tf
+++ b/examples/Create_OpenAI_Service_and_Models/variables.tf
@@ -122,10 +122,8 @@ variable "create_model_deployment" {
 
 variable "model_deployment" {
   type = list(object({
-    deployment_no   = number
     deployment_id   = string
-    api_type        = string
-    model           = string
+    model_name      = string
     model_format    = string
     model_version   = string
     scale_type      = string
@@ -138,12 +136,10 @@ variable "model_deployment" {
   default     = []
   description = <<-DESCRIPTION
       type = list(object({
-        deployment_no   = (Required) The unique number of each model deployment (Numbered when saved in Azure Key Vault).
         deployment_id   = (Required) The name of the Cognitive Services Account `Model Deployment`. Changing this forces a new resource to be created.
-        api_type        = (Required) The type of the Cognitive Services Account `Model Deployment`. Possible values are `azure`.
-        model = {
+        model_name = {
           model_format  = (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is OpenAI.
-          model         = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
+          model_name    = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
           model_version = (Required) The version of Cognitive Services Account Deployment model.
         }
         scale = {

--- a/main.tf
+++ b/main.tf
@@ -87,17 +87,9 @@ resource "azurerm_key_vault_secret" "openai_primary_key" {
   depends_on   = [azurerm_role_assignment.kv_role_assigment]
 }
 
-resource "azurerm_key_vault_secret" "openai_model_type" {
-  for_each     = { for each in var.model_deployment : each.deployment_id => each }
-  name         = "${var.openai_account_name}-model-${each.value.deployment_no}-type"
-  value        = each.value.api_type
-  key_vault_id = azurerm_key_vault.openai_kv.id
-  depends_on   = [azurerm_role_assignment.kv_role_assigment]
-}
-
 resource "azurerm_key_vault_secret" "openai_model_deployment_id" {
   for_each     = { for each in var.model_deployment : each.deployment_id => each }
-  name         = "${var.openai_account_name}-model-${each.value.deployment_no}-deployment-id"
+  name         = "${var.openai_account_name}-model-${each.value.deployment_id}-id"
   value        = each.value.deployment_id
   key_vault_id = azurerm_key_vault.openai_kv.id
   depends_on   = [azurerm_role_assignment.kv_role_assigment]
@@ -105,8 +97,8 @@ resource "azurerm_key_vault_secret" "openai_model_deployment_id" {
 
 resource "azurerm_key_vault_secret" "openai_model" {
   for_each     = { for each in var.model_deployment : each.deployment_id => each }
-  name         = "${var.openai_account_name}-model-${each.value.deployment_no}"
-  value        = each.value.model
+  name         = "${var.openai_account_name}-model-${each.value.deployment_id}-name"
+  value        = each.value.model_name
   key_vault_id = azurerm_key_vault.openai_kv.id
   depends_on   = [azurerm_role_assignment.kv_role_assigment]
 }

--- a/modules/model_deployment/main.tf
+++ b/modules/model_deployment/main.tf
@@ -7,7 +7,7 @@ resource "azurerm_cognitive_deployment" "model" {
 
   model {
     format  = each.value.model_format
-    name    = each.value.model
+    name    = each.value.model_name
     version = each.value.model_version
   }
   scale {

--- a/modules/model_deployment/variables.tf
+++ b/modules/model_deployment/variables.tf
@@ -12,10 +12,8 @@ variable "openai_account_name" {
 
 variable "model_deployment" {
   type = list(object({
-    deployment_no   = number
     deployment_id   = string
-    api_type        = string
-    model           = string
+    model_name      = string
     model_format    = string
     model_version   = string
     scale_type      = string
@@ -28,12 +26,10 @@ variable "model_deployment" {
   default     = []
   description = <<-DESCRIPTION
       type = list(object({
-        deployment_no   = (Required) The unique number of each model deployment (Numbered when saved in Azure Key Vault).
         deployment_id   = (Required) The name of the Cognitive Services Account `Model Deployment`. Changing this forces a new resource to be created.
-        api_type        = (Required) The type of the Cognitive Services Account `Model Deployment`. Possible values are `azure`.
-        model = {
+        model_name = {
           model_format  = (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is OpenAI.
-          model         = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
+          model_name    = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
           model_version = (Required) The version of Cognitive Services Account Deployment model.
         }
         scale = {

--- a/tests/auto_test1/testing.auto.tfvars
+++ b/tests/auto_test1/testing.auto.tfvars
@@ -34,19 +34,15 @@ openai_identity = {
 create_model_deployment = true
 model_deployment = [
   {
-    deployment_no = 1
-    deployment_id = "name-gpt-35-turbo-16k"
-    api_type      = "azure"
-    model         = "gpt-35-turbo-16k"
+    deployment_id = "gpt35turbo16k"
+    model_name    = "gpt-35-turbo-16k"
     model_format  = "OpenAI"
     model_version = "0613"
     scale_type    = "Standard"
   },
   {
-    deployment_no = 2
-    deployment_id = "name-gpt-35-turbo"
-    api_type      = "azure"
-    model         = "gpt-35-turbo"
+    deployment_id = "gpt35turbo"
+    model_name    = "gpt-35-turbo"
     model_format  = "OpenAI"
     model_version = "0613"
     scale_type    = "Standard"

--- a/tests/auto_test1/variables.tf
+++ b/tests/auto_test1/variables.tf
@@ -122,10 +122,8 @@ variable "create_model_deployment" {
 
 variable "model_deployment" {
   type = list(object({
-    deployment_no   = number
     deployment_id   = string
-    api_type        = string
-    model           = string
+    model_name      = string
     model_format    = string
     model_version   = string
     scale_type      = string
@@ -138,12 +136,10 @@ variable "model_deployment" {
   default     = []
   description = <<-DESCRIPTION
       type = list(object({
-        deployment_no   = (Required) The unique number of each model deployment (Numbered when saved in Azure Key Vault).
         deployment_id   = (Required) The name of the Cognitive Services Account `Model Deployment`. Changing this forces a new resource to be created.
-        api_type        = (Required) The type of the Cognitive Services Account `Model Deployment`. Possible values are `azure`.
-        model = {
+        model_name = {
           model_format  = (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is OpenAI.
-          model         = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
+          model_name    = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
           model_version = (Required) The version of Cognitive Services Account Deployment model.
         }
         scale = {

--- a/variables.tf
+++ b/variables.tf
@@ -202,10 +202,8 @@ variable "create_model_deployment" {
 
 variable "model_deployment" {
   type = list(object({
-    deployment_no   = number
     deployment_id   = string
-    api_type        = string
-    model           = string
+    model_name      = string
     model_format    = string
     model_version   = string
     scale_type      = string
@@ -218,12 +216,10 @@ variable "model_deployment" {
   default     = []
   description = <<-DESCRIPTION
       type = list(object({
-        deployment_no   = (Required) The unique number of each model deployment (Numbered when saved in Azure Key Vault).
         deployment_id   = (Required) The name of the Cognitive Services Account `Model Deployment`. Changing this forces a new resource to be created.
-        api_type        = (Required) The type of the Cognitive Services Account `Model Deployment`. Possible values are `azure`.
-        model = {
+        model_name = {
           model_format  = (Required) The format of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created. Possible value is OpenAI.
-          model         = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
+          model_name    = (Required) The name of the Cognitive Services Account Deployment model. Changing this forces a new resource to be created.
           model_version = (Required) The version of Cognitive Services Account Deployment model.
         }
         scale = {


### PR DESCRIPTION
simplify model deployment by removing unique key numbering inside of the model deployment variable