### PR TITLE
Fix for Unnecessary Recreations of Cognitive Deployments

### DIFF
--- a/modules/model_deployment/main.tf
+++ b/modules/model_deployment/main.tf
@@ -17,4 +17,10 @@ resource "azurerm_cognitive_deployment" "model" {
     family   = each.value.scale_family
     capacity = each.value.scale_capacity
   }
+
+  lifecycle {
+    ignore_changes = [
+      cognitive_account_id
+    ]
+  }
 }


### PR DESCRIPTION
**Description:**
This merge request introduces a change to the `azurerm_cognitive_deployment` resource configuration, which resolves the issue of unnecessary resource destruction and recreation reported in issue #52. The core problem was identified as frequent and unnecessary changes to the `cognitive_account_id` triggering resource replacement during Terraform apply phases.

**Changes Made:**
- Added a `lifecycle` block within the `azurerm_cognitive_deployment` resource definition to ignore changes to the `cognitive_account_id`. This modification ensures that the resource is not marked for replacement when the only change is the `cognitive_account_id`, which should not typically trigger a redeployment.

**Testing:**
The changes have been tested locally and verified to prevent unnecessary recreations of the `azurerm_cognitive_deployment` resource. The issue where Terraform would mark these resources for replacement, despite no meaningful changes, no longer occurs.
